### PR TITLE
移除一处调试用console.log

### DIFF
--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -145,7 +145,6 @@ function traverseUpload(localPath , that , files , countConf){
         return Promise.reject(error);
     }
     function uploaded(data){
-        console.log(data);
         countConf.success ++;
         countConf.successList.push({
             sourceUrl: data.Location,


### PR DESCRIPTION
此处的console.log会在上传时打出大量的请求信息，对于非调试的使用没有什么帮助，在上传大量文件时可能造成CI日志溢出