### PR TITLE
feat: v5支持retryConfig参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ cos.sync(conf.localPath conf.mime, conf.maxAge || conf.cacheMaxAge || 0, functio
 
 ## 历史
 
+### 1.8.0 2024-07-26
+- v5支持retryConfig参数，控制请求失败是否开启重试。对象参数包括`maxAttempts`控制重试最大次数；`interval`控制重试请求间隔单位是毫秒；`cosConfig`控制请求的cos实例对象配置参数，这里仅需控制是否启用全球加速域名即可，其他参数跟随cos对象初始化参数。配置示例
+`'retryConfig': {
+    'maxAttempts': 3,
+    'interval': 1000,
+    'cosConfig': {
+        'UseAccelerate': true,
+    }
+}`
+
 ### 1.7.0 2024-07-24
 - v5支持UseAccelerate参数，控制是否支持开启加速域名，默认为false则不开启，true则开启加速域名
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ cos.sync(conf.localPath conf.mime, conf.maxAge || conf.cacheMaxAge || 0, functio
 ## 历史
 
 ### 1.8.0 2024-07-26
-- v5支持retryConfig参数，控制请求失败是否开启重试。对象参数包括`maxAttempts`控制重试最大次数；`interval`控制重试请求间隔单位是毫秒；`cosConfig`控制请求的cos实例对象配置参数，这里仅需控制是否启用全球加速域名即可，其他参数跟随cos对象初始化参数。配置示例
+- v5支持retryConfig参数，控制请求失败是否开启重试。对象参数包括`maxAttempts`控制重试最大次数；`interval`控制重试请求间隔，单位是毫秒；`cosConfig`控制请求的cos实例对象配置参数，这里仅需控制是否启用全球加速域名即可，其他参数跟随cos对象初始化参数。配置示例
 `'retryConfig': {
     'maxAttempts': 3,
     'interval': 1000,

--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -71,29 +71,29 @@ function showProgress(countConf){
 /**
  * 重试方法
  */
-async function retryAction({
+function retryAction({
     retryConfig,
-    successCb,
-    failCb,
     retryFun,
     onFailedAttempt,
 }) {
-    try {
-        var pRetry = await import('p-retry');
-        var data = await pRetry.default(() => retryFun(), {
-            // 重试的次数不包括第一次
-            retries: retryConfig.maxAttempts - 1,
-            factor: 1,
-            minTimeout: retryConfig.interval,
-            maxTimeout: retryConfig.interval,
-            onFailedAttempt: (error) => {
-                onFailedAttempt(error)
-            },
-        });
-        return successCb(data)
-    } catch (err) {
-        return failCb(createError(err));
-    }
+    return new Promise(async function(resolve , reject){
+        try {
+            var pRetry = await import('p-retry');
+            var data = await pRetry.default(() => retryFun(), {
+                // 重试的次数不包括第一次
+                retries: retryConfig.maxAttempts - 1,
+                factor: 1,
+                minTimeout: retryConfig.interval,
+                maxTimeout: retryConfig.interval,
+                onFailedAttempt: (error) => {
+                    onFailedAttempt(error)
+                },
+            });
+            return resolve(data)
+        } catch (err) {
+            return reject(err);
+        }
+    })
 }
 /**
  * 上传方法
@@ -147,7 +147,7 @@ function uploadAction({
                 log(tip + '[Uploading] ' + filePath + ' => progress: ' + percent + '%. speed: ' + speed + ' kb/s\n');
             }
         }, async function (err, data) {
-            // 重试逻辑
+            // 重试
             if(err && retryConfig && retryConfig.cosConfig) {
                 log('[Upload]进入重试：' + filePath + '\n');
                 var retries = 1;
@@ -163,26 +163,30 @@ function uploadAction({
                     tip: '重试请求：',
                     ...apiOption,
                 }
+                var retryUploadAction = function(_retryOption) {
+                    return new Promise((_resolve, _reject) => {
+                        uploadAction(_retryOption).then(data => {
+                            _resolve(data);
+                        }).catch(err => {
+                            _reject(createError(err));
+                        });
+                    })
+                }
                 retryAction({
-                    secretId,
-                    secretKey,
-                    timeout,
                     retryConfig,
-                    successCb: (data) => {
-                        resolve(data)
-                    },
-                    failCb: (err) => {
-                        reject(createError(err))
-                    },
-                    retryFun: () => uploadAction(retryOption),
+                    retryFun: () => retryUploadAction(retryOption),
                     onFailedAttempt: (err) => {
                         log('第' + retries + '次重试失败:' + '[UploadFile  ] uploaded ' + filePath + ' is ' + (err ? 'error\n' : 'success.\n'));
                         retries++;
                     }
-                })
+                }).then(data => {
+                    resolve(data);
+                }).catch(err => {
+                    reject(err)
+                });
             } else {
                 log('[Upload]上传成功：' + filePath + '\n');
-                return err ? reject(createError(err)) : resolve(data);
+                return err ? reject(err) : resolve(data);
             }
         });
     });
@@ -191,7 +195,7 @@ function uploadAction({
 /**
  * 查询文件是否存在方法
  */
-function checkFile({
+function checkFileAction({
     cos,
     retryConfig,
     secretId,
@@ -200,7 +204,7 @@ function checkFile({
     bucket,
     region,
     filePath,
-    remoteFilePath
+    remoteFilePath,
 }) {
     return new Promise(function(resolve , reject){
         var apiOption = {
@@ -217,8 +221,8 @@ function checkFile({
             Region: region,    
             Key: remoteFilePath,               
         }, async function (err, data) {
-            // 重试逻辑
-            if(err && err.statusCode !== NotFoundCode && retryConfig && retryConfig.cosConfig) {
+            // 重试
+            if(err && retryConfig && retryConfig.cosConfig) {
                 log('[CheckFile]进入重试：' + filePath + '\n');
                 var retries = 1;
                 var cosAccelerate = new COS({
@@ -233,27 +237,33 @@ function checkFile({
                     tip: '重试请求：',
                     ...apiOption,
                 }
+                var retryCheckFileAction = function(_retryOption) {
+                    return new Promise((_resolve, _reject) => {
+                        checkFileAction(_retryOption).then(data => {
+                            _resolve(data);
+                        }).catch(err => {
+                            if( err.statusCode === NotFoundCode ) {
+                                _resolve(err);
+                            } else {
+                                _reject(createError(err));
+                            }
+                        });
+                    })
+                }
                 retryAction({
-                    secretId,
-                    secretKey,
-                    timeout,
                     retryConfig,
-                    successCb: (data) => {
-                        resolve(data)
-                    },
-                    failCb: (err) => {
-                        reject(err)
-                    },
-                    retryFun: () => checkFile(retryOption),
+                    retryFun: () => retryCheckFileAction(retryOption),
                     onFailedAttempt: (err) => {
                         log('[CheckFile] Checked '+ '第' + retries + '次重试失败:' + filePath + ' is ' + (err ? 'error\n' : 'success.\n'));
                         retries++;
                     }
-                })
-            } else if(err && err.statusCode === NotFoundCode) {
-                reject(err)
+                }).then(data => {
+                    resolve(data);
+                }).catch(err => {
+                    reject(err)
+                });
             } else {
-                log('[CheckFile]检测成功同名文件已上传，跳过当前上传步骤：' + filePath + '\n');
+                log('[CheckFile]检测结束：' + filePath + '\n');
                 return err ? reject(err) : resolve(data);
             }
           });
@@ -287,7 +297,7 @@ function uploadFile(that , remoteFilePath , filePath){
         var filename = encodeURIComponent(path.basename(remoteFilePath));
         var uploadFinishCallback = function (err, data) {
             log('[UploadFile 上传文件完成] uploaded ' + filePath + ' is ' + (err ? 'error\n\n' : 'success.\n\n'));
-            return err ? reject(createError(err)) : resolve(data);
+            return err ? reject(err) : resolve(data);
         }
         var uploadOption = {
             cos: that.cos,
@@ -317,7 +327,7 @@ function uploadFile(that , remoteFilePath , filePath){
                             uploadFinishCallback(err, null);
                         });
                     } else {
-                        return reject(createError(err))
+                        return reject(err)
                     }
                 } else {
                     log('[CheckFile Exist] Checked ' + filePath + ' is success.' + '\n\n');
@@ -339,8 +349,12 @@ function uploadFile(that , remoteFilePath , filePath){
                 filePath,
                 remoteFilePath
             }
-            checkFile(headObjectOptions).then(data => {
-                checkFinishCallback(null, data)
+            checkFileAction(headObjectOptions).then(data => {
+                if( data.statusCode === NotFoundCode ) {
+                    checkFinishCallback(data, null);
+                } else {
+                    checkFinishCallback(null, data)
+                }
             }).catch(err => {
                 checkFinishCallback(err, null);
             });

--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -182,7 +182,7 @@ function uploadAction({
                     reject(err)
                 });
             } else {
-                log('[Upload]上传成功：' + filePath + '\n');
+                log('[Upload]请求结束：' + filePath + '\n');
                 return err ? reject(err) : resolve(data);
             }
         });
@@ -293,7 +293,7 @@ function uploadFile(that , remoteFilePath , filePath){
     return new Promise(function(resolve , reject){
         var filename = encodeURIComponent(path.basename(remoteFilePath));
         var uploadFinishCallback = function (err, data) {
-            log('[UploadFile 上传文件完成] uploaded ' + filePath + ' is ' + (err ? 'error\n\n' : 'success.\n\n'));
+            log('[UploadFile 上传文件请求完成] uploaded ' + filePath + ' is ' + (err ? 'error\n\n' : 'success.\n\n'));
             return err ? reject(err) : resolve(data);
         }
         var uploadOption = {
@@ -314,6 +314,7 @@ function uploadFile(that , remoteFilePath , filePath){
         }
         if(that.skipWhenExist) {
             var checkFinishCallback = function (err, data) {
+                log('[CheckFile 检测文件请求完成] Checked ' + filePath + '\n');
                 if (err) {
                     log('[CheckFile err] Checked ' + filePath + '\n');
                     if (err.statusCode === NotFoundCode) {

--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -251,7 +251,7 @@ function checkFileAction({
                     retryConfig,
                     retryFun: () => createRetryAction({ retryOption, retryAction: checkFileAction }),
                     onFailedAttempt: (_err) => {
-                        log('[CheckFile] Checked '+ '第' + retries + '次重试失败:' + filePath + ' is ' + (_err ? 'error\n' : 'success.\n'));
+                        log('[CheckFile] Checked '+ '第' + retries + '次重试失败:' + filePath );
                         retries++;
                     }
                 }).then(data => {

--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -387,7 +387,7 @@ function traverseUpload(localPath , that , files , countConf){
         if ( !that.strict ) {
             return Promise.resolve(true);
         }
-        return Promise.reject(createError(err));
+        return Promise.reject(error);
     }
     function uploaded(data){
         countConf.success ++;

--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -5,6 +5,7 @@ var COS = require('cos-nodejs-sdk-v5');
 var glob   = require('glob');
 var mime   = require('mime');
 
+var NotFoundCode = 404;
 var log = getLog();
 /**
  * [getLog 打印信息函数]
@@ -43,7 +44,7 @@ function createError(error){
  * @return {[type]}          [description]
  */
 function traverseAllFiles(localPath , config){
-    log('[TraverseAllFiles   ] will traverse all files from ' + localPath + ' and config: ' + JSON.stringify(config) + '\n');
+    log('[TraverseAllFiles  获取需要上传的文件] will traverse all files from ' + localPath + ' and config: ' + JSON.stringify(config) + '\n');
 
     config.cwd = localPath || process.cwd();
 
@@ -52,7 +53,7 @@ function traverseAllFiles(localPath , config){
             if ( error ) {
                 return reject(createError(error));
             }else{
-                log('[TraverseAllFiles   ] ready to traverse all ' + files.length + ' files by folder.\n');
+                log('[TraverseAllFiles  获取需要上传的文件] ready to traverse all ' + files.length + ' files by folder.\n');
                 return resolve(files);
             }
         });
@@ -68,6 +69,198 @@ function showProgress(countConf){
 }
 
 /**
+ * 重试方法
+ */
+async function retryAction({
+    retryConfig,
+    successCb,
+    failCb,
+    retryFun,
+    onFailedAttempt,
+}) {
+    try {
+        var pRetry = await import('p-retry');
+        var data = await pRetry.default(() => retryFun(), {
+            // 重试的次数不包括第一次
+            retries: retryConfig.maxAttempts - 1,
+            factor: 1,
+            minTimeout: retryConfig.interval,
+            maxTimeout: retryConfig.interval,
+            onFailedAttempt: (error) => {
+                onFailedAttempt(error)
+            },
+        });
+        return successCb(data)
+    } catch (err) {
+        return failCb(createError(err));
+    }
+}
+/**
+ * 上传方法
+ */
+function uploadAction({
+    cos,
+    tip,
+    secretId,
+    secretKey,
+    timeout,
+    retryConfig,
+    bucket,
+    region,
+    remoteFilePath,
+    filePath,
+    maxAge,
+    thisMime,
+    expires,
+    filename,
+}) {
+    return new Promise(function(resolve , reject){
+        var apiOption = {
+            secretId,
+            secretKey,
+            timeout,
+            bucket,
+            region,
+            remoteFilePath,
+            filePath,
+            maxAge,
+            thisMime,
+            expires,
+            filename
+        }
+        cos.putObject({
+            Bucket: bucket,
+            Region: region,
+            Key: remoteFilePath,
+            Body: fs.createReadStream(filePath),
+            ContentLength: fs.statSync(filePath).size,
+            CacheControl: 'max-age=' + maxAge,
+            ContentType: thisMime,
+            Expires: expires,
+            ContentDisposition: 'filename*=UTF-8\'\'' + filename + '; filename="' + filename + '"',
+            onProgress: function (progressData) {
+                var percent = parseInt(progressData.percent * 10000) / 100;
+                // progressData.speed的初始值为null
+                var _speed = isNaN(Number(progressData.speed)) ? 0 : Number(progressData.speed);
+                var speed = (_speed / 1024).toFixed(2);
+    
+                log(tip + '[Uploading] ' + filePath + ' => progress: ' + percent + '%. speed: ' + speed + ' kb/s\n');
+            }
+        }, async function (err, data) {
+            // 重试逻辑
+            if(err && retryConfig && retryConfig.cosConfig) {
+                log('[Upload]进入重试：' + filePath + '\n');
+                var retries = 1;
+                var cosAccelerate = new COS({
+                    SecretId: secretId,
+                    SecretKey: secretKey,
+                    Timeout: timeout,
+                    // https://cloud.tencent.com/document/product/436/55438#.E5.85.A8.E7.90.83.E5.8A.A0.E9.80.9F.E5.9F.9F.E5.90.8D
+                    UseAccelerate: retryConfig.cosConfig.UseAccelerate, // 指定 true，使用全球加速域名请求
+                });
+                var retryOption = {
+                    cos: cosAccelerate,
+                    tip: '重试请求：',
+                    ...apiOption,
+                }
+                retryAction({
+                    secretId,
+                    secretKey,
+                    timeout,
+                    retryConfig,
+                    successCb: (data) => {
+                        resolve(data)
+                    },
+                    failCb: (err) => {
+                        reject(createError(err))
+                    },
+                    retryFun: () => uploadAction(retryOption),
+                    onFailedAttempt: (err) => {
+                        log('第' + retries + '次重试失败:' + '[UploadFile  ] uploaded ' + filePath + ' is ' + (err ? 'error\n' : 'success.\n'));
+                        retries++;
+                    }
+                })
+            } else {
+                log('[Upload]上传成功：' + filePath + '\n');
+                return err ? reject(createError(err)) : resolve(data);
+            }
+        });
+    });
+}
+
+/**
+ * 查询文件是否存在方法
+ */
+function checkFile({
+    cos,
+    retryConfig,
+    secretId,
+    secretKey,
+    timeout,
+    bucket,
+    region,
+    filePath,
+    remoteFilePath
+}) {
+    return new Promise(function(resolve , reject){
+        var apiOption = {
+            bucket,
+            region,
+            timeout,
+            remoteFilePath,
+            secretId,
+            secretKey,
+            filePath,
+        }
+        cos.headObject({
+            Bucket: bucket, 
+            Region: region,    
+            Key: remoteFilePath,               
+        }, async function (err, data) {
+            // 重试逻辑
+            if(err && err.statusCode !== NotFoundCode && retryConfig && retryConfig.cosConfig) {
+                log('[CheckFile]进入重试：' + filePath + '\n');
+                var retries = 1;
+                var cosAccelerate = new COS({
+                    SecretId: secretId,
+                    SecretKey: secretKey,
+                    Timeout: timeout,
+                    // https://cloud.tencent.com/document/product/436/55438#.E5.85.A8.E7.90.83.E5.8A.A0.E9.80.9F.E5.9F.9F.E5.90.8D
+                    UseAccelerate: retryConfig.cosConfig.UseAccelerate, // 指定 true，使用全球加速域名请求
+                });
+                var retryOption = {
+                    cos: cosAccelerate,
+                    tip: '重试请求：',
+                    ...apiOption,
+                }
+                retryAction({
+                    secretId,
+                    secretKey,
+                    timeout,
+                    retryConfig,
+                    successCb: (data) => {
+                        resolve(data)
+                    },
+                    failCb: (err) => {
+                        reject(err)
+                    },
+                    retryFun: () => checkFile(retryOption),
+                    onFailedAttempt: (err) => {
+                        log('[CheckFile] Checked '+ '第' + retries + '次重试失败:' + filePath + ' is ' + (err ? 'error\n' : 'success.\n'));
+                        retries++;
+                    }
+                })
+            } else if(err && err.statusCode === NotFoundCode) {
+                reject(err)
+            } else {
+                log('[CheckFile]检测成功同名文件已上传，跳过当前上传步骤：' + filePath + '\n');
+                return err ? reject(err) : resolve(data);
+            }
+          });
+    })
+}
+
+/**
  * [uploadFile 上传文件]
  * @param  {[type]} that            [cos-v5 obj]
  * @param  {[type]} remoteFilePath [description]
@@ -75,7 +268,7 @@ function showProgress(countConf){
  * @return {[type]}                [description]
  */
 function uploadFile(that , remoteFilePath , filePath){
-    log('[UploadFile   ] bucket: ' + that.bucket + ' region: ' + that.region + '\n');
+    log('[UploadFile 开始上传文件] bucket: ' + that.bucket + ' region: ' + that.region + '\n');
 
     var thisMime = '' ; 
     var thisExt = path.extname(remoteFilePath);
@@ -92,55 +285,72 @@ function uploadFile(that , remoteFilePath , filePath){
     //上传文件
     return new Promise(function(resolve , reject){
         var filename = encodeURIComponent(path.basename(remoteFilePath));
-        const uploadAction = () => {
-            that.cos.putObject({
-                Bucket: that.bucket,
-                Region: that.region,
-                Key: remoteFilePath,
-                Body: fs.createReadStream(filePath),
-                ContentLength: fs.statSync(filePath).size,
-                CacheControl: 'max-age=' + that.maxAge,
-                ContentType : thisMime,
-                Expires: that.expires,
-                ContentDisposition: 'filename*=UTF-8\'\'' + filename + '; filename="' + filename + '"',
-                onProgress: function (progressData) {
-                    var percent = parseInt(progressData.percent * 10000) / 100;
-                    // progressData.speed的初始值为null
-                    var _speed = isNaN(Number(progressData.speed)) ? 0 : Number(progressData.speed);
-                    var speed = (_speed / 1024).toFixed(2);
-                     
-                    log('[Uploading  ] ' + filePath +' => progress: ' + percent + '%. speed: ' + speed + ' kb/s\n');
-                }
-            }, function (err, data) {
-                log('[UploadFile  ] uploaded ' + filePath +' is ' + (err ? 'error\n' : 'success.\n'));
-                return err ? reject(err) : resolve(data);
-            });
+        var uploadFinishCallback = function (err, data) {
+            log('[UploadFile 上传文件完成] uploaded ' + filePath + ' is ' + (err ? 'error\n\n' : 'success.\n\n'));
+            return err ? reject(createError(err)) : resolve(data);
+        }
+        var uploadOption = {
+            cos: that.cos,
+            retryConfig: that.retryConfig,
+            tip: '',
+            secretId: that.secretId,
+            secretKey: that.secretKey,
+            timeout: that.timeout,
+            bucket: that.bucket,
+            region: that.region,
+            remoteFilePath,
+            filePath,
+            maxAge: that.maxAge,
+            thisMime,
+            expires: that.expires,
+            filename
         }
         if(that.skipWhenExist) {
-            const NoFoundCode = 404;
-            that.cos.headObject({
-                Bucket: that.bucket, 
-                Region: that.region,    
-                Key: remoteFilePath,               
-            }, function (err, data) {
+            var checkFinishCallback = function (err, data) {
                 if (err) {
-                    if(err.statusCode === NoFoundCode) {
-                        uploadAction();
+                    log('[CheckFile err] Checked ' + filePath + '\n');
+                    if (err.statusCode === NotFoundCode) {
+                        log('[CheckFile notFound] Checked ' + filePath);
+                        uploadAction(uploadOption).then(data => {
+                            uploadFinishCallback(null, data);
+                        }).catch((err) => {
+                            uploadFinishCallback(err, null);
+                        });
                     } else {
-                        return reject(err)
+                        return reject(createError(err))
                     }
                 } else {
-                    log('[UploadFile  skipWhenExist] uploaded ' + filePath +' is success.');
-                    data = Object.assign({}, data, { 
-                        Location: `${that.bucket}.cos.${that.region}.myqcloud.com${remoteFilePath}` 
-                    }); 
+                    log('[CheckFile Exist] Checked ' + filePath + ' is success.' + '\n\n');
+                    data = Object.assign({}, data, {
+                        Location: `${that.bucket}.cos.${that.region}.myqcloud.com${remoteFilePath}`
+                    });
                     return resolve(data);
                 }
-              });
+            }
+            var headObjectOptions = {
+                cos: that.cos,
+                tip: '',
+                retryConfig: that.retryConfig,
+                secretId: that.secretId,
+                secretKey: that.secretKey,
+                timeout: that.timeout,
+                bucket: that.bucket,
+                region: that.region,
+                filePath,
+                remoteFilePath
+            }
+            checkFile(headObjectOptions).then(data => {
+                checkFinishCallback(null, data)
+            }).catch(err => {
+                checkFinishCallback(err, null);
+            });
         } else {
-            uploadAction();
+            uploadAction(uploadOption).then(data => {
+                uploadFinishCallback(null, data);
+            }).catch((err) => {
+                uploadFinishCallback(err, null);
+            });
         }
-        
     });
 }
 
@@ -162,7 +372,7 @@ function traverseUpload(localPath , that , files , countConf){
     var filePath = path.posix.normalize(path.join(localPath , file)); 
     var remoteFilePath = (that.remotePath + file).replace(/\/+/img , '/');
 
-    log('[TraverseUpload   ] will upload file : ' + filePath + ' => ' + remoteFilePath + '\n');
+    log('[TraverseUpload  逐个递归上传所有文件] will upload file : ' + filePath + ' => ' + remoteFilePath + '\n');
 
     function catchError(error){
         countConf.fail++;
@@ -170,7 +380,7 @@ function traverseUpload(localPath , that , files , countConf){
         if ( !that.strict ) {
             return Promise.resolve(true);
         }
-        return Promise.reject(error);
+        return Promise.reject(createError(error));
     }
     function uploaded(data){
         countConf.success ++;
@@ -207,7 +417,11 @@ function CosV5(config){
         UseAccelerate: config.UseAccelerate,
         Timeout: config.timeout || 120000
     });
+    this.secretId = config.secretId;
+    this.secretKey = config.secretKey;
+    this.timeout = config.timeout || 120000;
     this.skipWhenExist = config.skipWhenExist ? config.skipWhenExist : false;
+    this.retryConfig = config.retryConfig;
     this.region = config.region;
     this.remotePath = config.remotePath;
     this.bucket = config.bucket;

--- a/lib/cos-v5.js
+++ b/lib/cos-v5.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var COS = require('cos-nodejs-sdk-v5');
 var glob   = require('glob');
 var mime   = require('mime');
+var retry = require('retry');
 
 var NotFoundCode = 404;
 var log = getLog();
@@ -34,8 +35,8 @@ function isNodeEnv(){
  * @param  {[type]} errorMsg [description]
  * @return {[Error]}          [description]
  */
-function createError(error){
-    return (error instanceof Error) ? error : new Error(error);
+function createError(err){
+    return (err instanceof Error) ? err : new Error(err);
 }
 /**
  * [traverseAllFiles 获取需要上传的文件]
@@ -49,9 +50,9 @@ function traverseAllFiles(localPath , config){
     config.cwd = localPath || process.cwd();
 
     return new Promise(function(resolve , reject){
-        glob(config.pattern || '**/*' , config , function(error , files){
-            if ( error ) {
-                return reject(createError(error));
+        glob(config.pattern || '**/*' , config , function(err , files){
+            if ( err ) {
+                return reject(createError(err));
             }else{
                 log('[TraverseAllFiles  获取需要上传的文件] ready to traverse all ' + files.length + ' files by folder.\n');
                 return resolve(files);
@@ -76,25 +77,30 @@ function retryAction({
     retryFun,
     onFailedAttempt,
 }) {
-    return new Promise(async function(resolve , reject){
-        try {
-            var pRetry = await import('p-retry');
-            var data = await pRetry.default(() => retryFun(), {
-                // 重试的次数不包括第一次
-                retries: retryConfig.maxAttempts - 1,
-                factor: 1,
-                minTimeout: retryConfig.interval,
-                maxTimeout: retryConfig.interval,
-                onFailedAttempt: (error) => {
-                    onFailedAttempt(error)
-                },
-            });
-            return resolve(data)
-        } catch (err) {
-            return reject(err);
-        }
-    })
+    return new Promise((resolve, reject) => {
+        const operation = retry.operation({
+            retries: retryConfig.maxAttempts - 1, // 重试的次数不包括第一次
+            factor: 1,
+            minTimeout: retryConfig.interval,
+            maxTimeout: retryConfig.interval,
+        });
+
+        operation.attempt(() => {
+            retryFun()
+                .then((data) => {
+                    resolve(data);
+                })
+                .catch((err) => {
+                    onFailedAttempt(err);
+                    if (operation.retry(err)) {
+                        return;
+                    }
+                    reject(err);
+                });
+        });
+    });
 }
+
 /**
  * 上传方法
  */
@@ -163,25 +169,16 @@ function uploadAction({
                     tip: '重试请求：',
                     ...apiOption,
                 }
-                var retryUploadAction = function(_retryOption) {
-                    return new Promise((_resolve, _reject) => {
-                        uploadAction(_retryOption).then(data => {
-                            _resolve(data);
-                        }).catch(err => {
-                            _reject(createError(err));
-                        });
-                    })
-                }
                 retryAction({
                     retryConfig,
-                    retryFun: () => retryUploadAction(retryOption),
-                    onFailedAttempt: (err) => {
-                        log('第' + retries + '次重试失败:' + '[UploadFile  ] uploaded ' + filePath + ' is ' + (err ? 'error\n' : 'success.\n'));
+                    retryFun: () => createRetryAction({ retryOption, retryAction: uploadAction }),
+                    onFailedAttempt: (_err) => {
+                        log('第' + retries + '次重试失败:' + '[UploadFile  ] uploaded ' + filePath + ' is ' + (_err ? 'error\n' : 'success.\n'));
                         retries++;
                     }
                 }).then(data => {
                     resolve(data);
-                }).catch(err => {
+                }).catch((_err) => {
                     reject(err)
                 });
             } else {
@@ -190,6 +187,19 @@ function uploadAction({
             }
         });
     });
+}
+
+/**
+ * 构建用于重试的方法
+ */
+function createRetryAction({ retryOption, retryAction }) {
+    return new Promise((resolve, reject) => {
+        retryAction(retryOption).then(data => {
+            resolve(data);
+        }).catch(err => {
+            reject(err);
+        });
+    })
 }
 
 /**
@@ -237,30 +247,17 @@ function checkFileAction({
                     tip: '重试请求：',
                     ...apiOption,
                 }
-                var retryCheckFileAction = function(_retryOption) {
-                    return new Promise((_resolve, _reject) => {
-                        checkFileAction(_retryOption).then(data => {
-                            _resolve(data);
-                        }).catch(err => {
-                            if( err.statusCode === NotFoundCode ) {
-                                _resolve(err);
-                            } else {
-                                _reject(createError(err));
-                            }
-                        });
-                    })
-                }
                 retryAction({
                     retryConfig,
-                    retryFun: () => retryCheckFileAction(retryOption),
-                    onFailedAttempt: (err) => {
-                        log('[CheckFile] Checked '+ '第' + retries + '次重试失败:' + filePath + ' is ' + (err ? 'error\n' : 'success.\n'));
+                    retryFun: () => createRetryAction({ retryOption, retryAction: checkFileAction }),
+                    onFailedAttempt: (_err) => {
+                        log('[CheckFile] Checked '+ '第' + retries + '次重试失败:' + filePath + ' is ' + (_err ? 'error\n' : 'success.\n'));
                         retries++;
                     }
                 }).then(data => {
                     resolve(data);
-                }).catch(err => {
-                    reject(err)
+                }).catch((_err) => {
+                    reject(_err)
                 });
             } else {
                 log('[CheckFile]检测结束：' + filePath + '\n');
@@ -350,11 +347,7 @@ function uploadFile(that , remoteFilePath , filePath){
                 remoteFilePath
             }
             checkFileAction(headObjectOptions).then(data => {
-                if( data.statusCode === NotFoundCode ) {
-                    checkFinishCallback(data, null);
-                } else {
-                    checkFinishCallback(null, data)
-                }
+                checkFinishCallback(null, data);
             }).catch(err => {
                 checkFinishCallback(err, null);
             });
@@ -388,13 +381,13 @@ function traverseUpload(localPath , that , files , countConf){
 
     log('[TraverseUpload  逐个递归上传所有文件] will upload file : ' + filePath + ' => ' + remoteFilePath + '\n');
 
-    function catchError(error){
+    function catchError(err){
         countConf.fail++;
         countConf.failList.push(file);
         if ( !that.strict ) {
             return Promise.resolve(true);
         }
-        return Promise.reject(createError(error));
+        return Promise.reject(createError(err));
     }
     function uploaded(data){
         countConf.success ++;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cos-nodejs-sdk-v5": "^2.4.9",
     "glob": "^7.0.6",
     "mime": "^1.3.4",
-    "p-retry": "^6.2.0",
-    "qcloud_cos": "^1.0.5"
+    "qcloud_cos": "^1.0.5",
+    "retry": "^0.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cos-nodejs-sdk-v5": "^2.4.9",
     "glob": "^7.0.6",
     "mime": "^1.3.4",
+    "p-retry": "^6.2.0",
     "qcloud_cos": "^1.0.5"
   }
 }


### PR DESCRIPTION
v5支持retryConfig参数，控制请求失败是否开启重试。对象参数包括`maxAttempts`控制重试最大次数；`interval`控制重试请求间隔，单位是毫秒；`cosConfig`控制请求的cos实例对象配置参数，这里仅需控制是否启用全球加速域名即可，其他参数跟随cos对象初始化参数。配置示例
`'retryConfig': {
    'maxAttempts': 3,
    'interval': 1000,
    'cosConfig': {
        'UseAccelerate': true,
    }
}`